### PR TITLE
refactor(test): made BaseMvcTest more useful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,14 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: gradle dependencies
+      - run: ./gradlew dependencies
 
       - save_cache:
           paths:
-            - ~/.gradle
+            - ~/.gradlew
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
       # run tests!
-      - run: gradle test
-      - run: gradle jacocoTestReport
+      - run: ./gradlew test
+      - run: ./gradlew jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)

--- a/src/test/java/com/bts/essentials/BaseMvcTest.java
+++ b/src/test/java/com/bts/essentials/BaseMvcTest.java
@@ -2,6 +2,8 @@ package com.bts.essentials;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.Filter;
@@ -12,9 +14,15 @@ import javax.servlet.Filter;
 @AutoConfigureMockMvc
 public abstract class BaseMvcTest extends BaseIntegrationTest {
 
+    protected MockMvc mockMvc;
+
     @Autowired
     protected WebApplicationContext webApplicationContext;
 
     @Autowired()
     protected Filter springSecurityFilterChain;
+
+    protected void initializeMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).addFilters(springSecurityFilterChain).build();
+    }
 }

--- a/src/test/java/com/bts/essentials/authentication/config/AbstractSecurityConfigurerAdapterTest.java
+++ b/src/test/java/com/bts/essentials/authentication/config/AbstractSecurityConfigurerAdapterTest.java
@@ -68,8 +68,6 @@ class TestController {
  */
 public class AbstractSecurityConfigurerAdapterTest extends BaseMvcTest {
 
-    private MockMvc mockMvc;
-
     @Autowired
     private TestAbstractSecurityConfigurerAdapter testAbstractSecurityConfigurerAdapter;
 
@@ -81,7 +79,7 @@ public class AbstractSecurityConfigurerAdapterTest extends BaseMvcTest {
 
     @Before
     public void before() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).addFilters(springSecurityFilterChain).build();
+        initializeMockMvc();
     }
 
     @Test


### PR DESCRIPTION
Updated BaseMvcTest to contain the MockMvc initialization logic rather than having it be implemented in the subclasses.