### PR TITLE
chore(renovate): updated renovate config to have gradle enabled

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "gradle": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
Added renovate's gradle enabled flag to hopefully get renovate to update the gradle.properties rather than updating the gradle.build file.