### PR TITLE
chore(deps): testing removing string interpolation of version numbers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     compile group: 'com.google.guava', name: 'guava', version: "${guavaVersion}"
-    compile group: 'com.google.api-client', name: 'google-api-client', version: "${googleApiClientVersion}"
+    compile group: 'com.google.api-client', name: 'google-api-client', version: googleApiClientVersion
     compile group: 'io.jsonwebtoken', name: 'jjwt', version: "${jjwtVersion}"
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testCompile group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"


### PR DESCRIPTION
Updated the Google API Client version to use the raw variable instead of relying on String interpolation to see if Renovate will properly update the gradle.properties instead of the build.gradle with updated dependency versions.