### PR TITLE
chore(deps): directly used gradle vars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,11 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-    compile group: 'com.google.guava', name: 'guava', version: "${guavaVersion}"
-    compile group: 'com.google.api-client', name: 'google-api-client', version: "${googleApiClientVersion}"
-    compile group: 'io.jsonwebtoken', name: 'jjwt', version: "${jjwtVersion}"
+    compile group: 'com.google.guava', name: 'guava', version: guavaVersion
+    compile group: 'com.google.api-client', name: 'google-api-client', version: googleApiClientVersion
+    compile group: 'io.jsonwebtoken', name: 'jjwt', version: jjwtVersion
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
+    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
 }
 
 dependencyManagement {


### PR DESCRIPTION
Updated the build.gradle to directly use the gradle vars rather than perform string interpolation in the depencency versions